### PR TITLE
Bugfix/default system prompt prefix

### DIFF
--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -987,12 +987,15 @@ buildSystemPrompt // beginDefinition;
 
 buildSystemPrompt[ as_Association ] := TemplateApply[
     $promptTemplate,
+    Association[
+        $promptComponents[ "Generic" ],
     Select[
         <|
             "Pre"  -> Lookup[ as, "ChatContextPreprompt"  ],
             "Post" -> Lookup[ as, "ChatContextPostPrompt" ]
         |>,
         StringQ
+    ]
     ]
 ];
 

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -1382,7 +1382,7 @@ $promptStrings := $promptStrings = Association @ Map[
         StringDelete[
             StringReplace[ ResourceFunction[ "RelativePath" ][ $promptDirectory, # ], "\\" -> "/" ],
             ".md"~~EndOfString
-        ] -> ByteArrayToString @ ReadByteArray @ #
+        ] -> StringReplace[ ByteArrayToString @ ReadByteArray @ #, "\r\n" -> "\n" ]
     ],
     FileNames[ "*.md", $promptDirectory, Infinity ]
 ];


### PR DESCRIPTION
The [default prompt prefix](https://github.com/ConnorGray/LLMTools/blob/main/Assets/AIAssistant/Prompts/Generic/Pre.md) wasn't getting used when there was no user-specified ChatContextPreprompt.

That's supposed to get plugged into the `%%Pre%%` slot in [the main prompt template](https://github.com/ConnorGray/LLMTools/blob/main/Assets/AIAssistant/Prompts/Default.md) as a default value.

Side note: GPT-4 is pretty good at helping debug itself:

<img width="779" alt="image" src="https://user-images.githubusercontent.com/6674723/233224984-ae3b9eed-655c-4fbb-abaa-66b404138fce.png">
