### PR TITLE
Hooked up `CopyChatObject` action to chat output menu

### DIFF
--- a/Developer/Resources/Styles.wl
+++ b/Developer/Resources/Styles.wl
@@ -465,7 +465,7 @@ Cell[
                 },
                 "Highlighted"
             ],
-            ButtonFunction :> (ReleaseHold @ #3; NotebookDelete @ EvaluationCell[ ]),
+            ButtonFunction :> ReleaseHold @ #3,
             Appearance     -> $suppressButtonAppearance,
             Method         -> "Queued",
             Evaluator      -> Automatic

--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -1376,9 +1376,7 @@ Notebook[
         },
         "Highlighted"
        ],
-       ButtonFunction :>
-        (ReleaseHold[#3];
-        NotebookDelete[EvaluationCell[]]),
+       ButtonFunction :> ReleaseHold[#3],
        Appearance ->
         Dynamic[
          FEPrivate`FrontEndResource[
@@ -1408,17 +1406,17 @@ Notebook[
               {
                TemplateBox[{"IconizeIcon"}, "ChatMenuItemToolbarIcon"],
                "\"Regenerate\"",
-               Hold[MessageDialog["Not Implemented"]]
-              },
-              "ChatMenuItem"
-             ]
-            },
-            {
-             TemplateBox[
-              {
-               TemplateBox[{"DrawIcon"}, "ChatMenuItemToolbarIcon"],
-               "\"Edit\"",
-               Hold[MessageDialog["Not Implemented"]]
+               Hold[
+                With[ { cell$ = EvaluationCell[] },
+                 {root$ = ParentCell[cell$]},
+                 NotebookDelete[cell$];
+                 Quiet[Needs["Wolfram`Chatbook`" -> None]];
+                 Symbol["Wolfram`Chatbook`ChatbookAction"][
+                  "Regenerate",
+                  root$
+                 ]
+                ]
+               ]
               },
               "ChatMenuItem"
              ]
@@ -1429,7 +1427,17 @@ Notebook[
               {
                TemplateBox[{"DivideCellsIcon"}, "ChatMenuItemToolbarIcon"],
                "\"Explode Cells (In Place)\"",
-               Hold[MessageDialog["Not Implemented"]]
+               Hold[
+                With[ { cell$ = EvaluationCell[] },
+                 {root$ = ParentCell[cell$]},
+                 NotebookDelete[cell$];
+                 Quiet[Needs["Wolfram`Chatbook`" -> None]];
+                 Symbol["Wolfram`Chatbook`ChatbookAction"][
+                  "ExplodeInPlace",
+                  root$
+                 ]
+                ]
+               ]
               },
               "ChatMenuItem"
              ]
@@ -1439,7 +1447,17 @@ Notebook[
               {
                TemplateBox[{"OverflowIcon"}, "ChatMenuItemToolbarIcon"],
                "\"Explode Cells (Duplicate)\"",
-               Hold[MessageDialog["Not Implemented"]]
+               Hold[
+                With[ { cell$ = EvaluationCell[] },
+                 {root$ = ParentCell[cell$]},
+                 NotebookDelete[cell$];
+                 Quiet[Needs["Wolfram`Chatbook`" -> None]];
+                 Symbol["Wolfram`Chatbook`ChatbookAction"][
+                  "ExplodeDuplicate",
+                  root$
+                 ]
+                ]
+               ]
               },
               "ChatMenuItem"
              ]
@@ -1452,7 +1470,17 @@ Notebook[
                 "ChatMenuItemToolbarIcon"
                ],
                "\"Copy Exploded Cells\"",
-               Hold[MessageDialog["Not Implemented"]]
+               Hold[
+                With[ { cell$ = EvaluationCell[] },
+                 {root$ = ParentCell[cell$]},
+                 NotebookDelete[cell$];
+                 Quiet[Needs["Wolfram`Chatbook`" -> None]];
+                 Symbol["Wolfram`Chatbook`ChatbookAction"][
+                  "CopyExplodedCells",
+                  root$
+                 ]
+                ]
+               ]
               },
               "ChatMenuItem"
              ]
@@ -1463,7 +1491,17 @@ Notebook[
               {
                TemplateBox[{"TypesettingIcon"}, "ChatMenuItemToolbarIcon"],
                "\"Toggle Formatting\"",
-               Hold[MessageDialog["Not Implemented"]]
+               Hold[
+                With[ { cell$ = EvaluationCell[] },
+                 {root$ = ParentCell[cell$]},
+                 NotebookDelete[cell$];
+                 Quiet[Needs["Wolfram`Chatbook`" -> None]];
+                 Symbol["Wolfram`Chatbook`ChatbookAction"][
+                  "ToggleFormatting",
+                  root$
+                 ]
+                ]
+               ]
               },
               "ChatMenuItem"
              ]
@@ -1472,8 +1510,18 @@ Notebook[
              TemplateBox[
               {
                TemplateBox[{"InPlaceIcon"}, "ChatMenuItemToolbarIcon"],
-               "\"View Raw Messages\"",
-               Hold[MessageDialog["Not Implemented"]]
+               "\"Copy ChatObject\"",
+               Hold[
+                With[ { cell$ = EvaluationCell[] },
+                 {root$ = ParentCell[cell$]},
+                 NotebookDelete[cell$];
+                 Quiet[Needs["Wolfram`Chatbook`" -> None]];
+                 Symbol["Wolfram`Chatbook`ChatbookAction"][
+                  "CopyChatObject",
+                  root$
+                 ]
+                ]
+               ]
               },
               "ChatMenuItem"
              ]
@@ -1483,7 +1531,17 @@ Notebook[
               {
                TemplateBox[{"GroupCellsIcon"}, "ChatMenuItemToolbarIcon"],
                "\"Lock Response\"",
-               Hold[MessageDialog["Not Implemented"]]
+               Hold[
+                With[ { cell$ = EvaluationCell[] },
+                 {root$ = ParentCell[cell$]},
+                 NotebookDelete[cell$];
+                 Quiet[Needs["Wolfram`Chatbook`" -> None]];
+                 Symbol["Wolfram`Chatbook`ChatbookAction"][
+                  "LockResponse",
+                  root$
+                 ]
+                ]
+               ]
               },
               "ChatMenuItem"
              ]
@@ -1493,7 +1551,17 @@ Notebook[
               {
                TemplateBox[{"AbortAllIcon"}, "ChatMenuItemToolbarIcon"],
                "\"Disable AI Assistant\"",
-               Hold[MessageDialog["Not Implemented"]]
+               Hold[
+                With[ { cell$ = EvaluationCell[] },
+                 {root$ = ParentCell[cell$]},
+                 NotebookDelete[cell$];
+                 Quiet[Needs["Wolfram`Chatbook`" -> None]];
+                 Symbol["Wolfram`Chatbook`ChatbookAction"][
+                  "DisableAIAssistant",
+                  root$
+                 ]
+                ]
+               ]
               },
               "ChatMenuItem"
              ]

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -3,11 +3,14 @@
 (*Package Header*)
 BeginPackage[ "Wolfram`Chatbook`Actions`" ];
 
+(* TODO: these probably aren't needed as exported symbols since all hooks are going through ChatbookAction *)
 `AskChat;
+`AttachCodeButtons;
+`CopyChatObject;
 `ExclusionToggle;
+`OpenChatMenu;
 `SendChat;
 `WidgetSend;
-`AttachCodeButtons;
 
 Begin[ "`Private`" ];
 
@@ -116,7 +119,6 @@ endDefinition // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*ChatbookAction*)
-ChatbookAction // beginDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
@@ -142,14 +144,51 @@ ChatbookAction::UnknownStatusCode =
 ChatbookAction::BadResponseMessage =
 "`1`";
 
+ChatbookAction::NotImplemented =
+"Action \"`1`\" is not implemented.";
+
 ChatbookAction[ "Ask"              , args___ ] := catchTop @ AskChat @ args;
+ChatbookAction[ "AttachCodeButtons", args___ ] := catchTop @ AttachCodeButtons @ args;
+ChatbookAction[ "CopyChatObject"   , args___ ] := catchTop @ CopyChatObject @ args;
+ChatbookAction[ "ExclusionToggle"  , args___ ] := catchTop @ ExclusionToggle @ args;
+ChatbookAction[ "OpenChatMenu"     , args___ ] := catchTop @ OpenChatMenu @ args;
 ChatbookAction[ "Send"             , args___ ] := catchTop @ SendChat @ args;
 ChatbookAction[ "WidgetSend"       , args___ ] := catchTop @ WidgetSend @ args;
-ChatbookAction[ "ExclusionToggle"  , args___ ] := catchTop @ ExclusionToggle @ args;
-ChatbookAction[ "AttachCodeButtons", args___ ] := catchTop @ AttachCodeButtons @ args;
-ChatbookAction[ "OpenChatMenu"     , args___ ] := catchTop @ OpenChatMenu @ args;
+ChatbookAction[ name_String        , args___ ] := catchTop @ throwFailure[ ChatbookAction::NotImplemented, name, args ];
+ChatbookAction[ args___                      ] := catchTop @ throwInternalFailure @ HoldForm @ ChatbookAction @ args;
 
-ChatbookAction // endDefinition;
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*CopyChatObject*)
+CopyChatObject // beginDefinition;
+
+CopyChatObject[ cell_CellObject ] := Enclose[
+    Module[ { encodedString, chatData, messages, chatObject },
+        encodedString = ConfirmBy[ CurrentValue[ cell, { TaggingRules, "ChatData" } ], StringQ ];
+        chatData      = ConfirmBy[ BinaryDeserialize @ BaseDecode @ encodedString, AssociationQ ];
+        messages      = ConfirmMatch[ chatData[ "Data", "Messages" ], { __Association? AssociationQ } ];
+        chatObject    = Confirm @ constructChatObject @ messages;
+        CopyToClipboard @ chatObject
+    ],
+    throwInternalFailure[ HoldForm @ CopyChatObject @ cell, ## ] &
+];
+
+CopyChatObject // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*constructChatObject*)
+constructChatObject // beginDefinition;
+
+constructChatObject[ messages_List ] :=
+    With[ { chat = System`CreateChat[ Append[ KeyMap[ Capitalize, #1 ], "Timestamp" -> Now ] & /@ messages ] },
+        chat /; MatchQ[ chat, _System`ChatObject ]
+    ];
+
+constructChatObject[ messages_List ] :=
+    Dataset[ KeyMap[ Capitalize ] /@ messages ];
+
+constructChatObject // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
@@ -575,7 +614,7 @@ queuedEvaluationsQ[ ___ ] := False;
 sendChat // beginDefinition;
 
 sendChat[ evalCell_, nbo_, settings0_ ] := catchTop @ Enclose[
-    Module[ { cells, settings, id, key, req, cell, cellObject, container, task },
+    Module[ { cells, settings, id, key, req, data, cell, cellObject, container, task },
 
         cells    = ConfirmMatch[ selectChatCells[ settings0, evalCell, nbo ], { __CellObject }, "SelectChatCells" ];
         settings = ConfirmBy[ inheritSettings[ settings0, cells, evalCell ], AssociationQ, "InheritSettings" ];
@@ -584,11 +623,18 @@ sendChat[ evalCell_, nbo_, settings0_ ] := catchTop @ Enclose[
 
         If[ ! StringQ @ key, throwFailure[ "NoAPIKey" ] ];
 
-        req = ConfirmMatch[
-            makeHTTPRequest[ Append[ settings, "OpenAIKey" -> key ], cells ],
-            _HTTPRequest,
-            "MakeHTTPRequest"
+        { req, data } = Reap[
+            ConfirmMatch[
+                makeHTTPRequest[ Append[ settings, "OpenAIKey" -> key ], cells ],
+                _HTTPRequest,
+                "MakeHTTPRequest"
+            ],
+            $chatDataTag
         ];
+
+        data = ConfirmBy[ Association @ Flatten @ data, AssociationQ, "Data" ];
+
+        AppendTo[ settings, "Data" -> data ];
 
         container = ProgressIndicator[ Appearance -> "Percolate" ];
         cell = activeAIAssistantCell[ container, settings ];
@@ -927,6 +973,8 @@ makeHTTPRequest[ settings_Association? AssociationQ, messages: { __Association }
             |>,
             Automatic|_Missing
         ];
+
+        Sow[ <| "Messages" -> messages |>, $chatDataTag ];
 
         body = ConfirmBy[ Developer`WriteRawJSONString[ data, "Compact" -> True ], StringQ ];
 
@@ -1685,7 +1733,11 @@ reformatCell[ settings_, string_, tag_, open_, label_ ] := Cell[
     "ChatOutput",
     GeneratedCell     -> True,
     CellAutoOverwrite -> True,
-    TaggingRules      -> <| "CellToStringData" -> string, "MessageTag" -> tag |>,
+    TaggingRules      -> <|
+        "CellToStringData" -> string,
+        "MessageTag"       -> tag,
+        "ChatData"         -> makeCompactChatData[ string, tag, settings ]
+    |>,
     If[ TrueQ @ open,
         Sequence @@ { },
         Sequence @@ Flatten @ {
@@ -1696,6 +1748,30 @@ reformatCell[ settings_, string_, tag_, open_, label_ ] := Cell[
 ];
 
 reformatCell // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*makeCompactChatData*)
+makeCompactChatData // beginDefinition;
+
+makeCompactChatData[
+    message_,
+    tag_,
+    as: KeyValuePattern[ "Data" -> data: KeyValuePattern[ "Messages" -> messages_List ] ]
+] :=
+    BaseEncode @ BinarySerialize[
+        Association[
+            as,
+            "MessageTag" -> tag,
+            "Data" -> Association[
+                data,
+                "Messages" -> Append[ messages, <| "role" -> "assistant", "content" -> message |> ]
+            ]
+        ],
+        PerformanceGoal -> "Size"
+    ];
+
+makeCompactChatData // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)


### PR DESCRIPTION
This is just a basic implementation to generate a `ChatObject` from a chat output cell using the menu:

<img width="785" alt="Screenshot 2023-04-19 201730" src="https://user-images.githubusercontent.com/6674723/233226217-6c5431d1-02e5-4f64-b7fd-71a2886915e9.png">

<img width="845" alt="Screenshot 2023-04-19 201825" src="https://user-images.githubusercontent.com/6674723/233226269-b122e025-1618-4263-8ce1-f09ebca75bc6.png">

If `CreateChat` is undefined, it copies a `Dataset` containing the messages instead.